### PR TITLE
perf(compile): thread-pool the read loops + game_rosters json/final fallback

### DIFF
--- a/python/wnba_data_build/build.py
+++ b/python/wnba_data_build/build.py
@@ -8,12 +8,10 @@ season.
 
 from __future__ import annotations
 
-import sys
 import time
 from pathlib import Path
 
 import polars as pl
-from tqdm import tqdm
 
 from wnba_data_build import ingest, io, publish, reshapers
 from wnba_data_build._logging import get_logger
@@ -21,7 +19,7 @@ from wnba_data_build.config import REGISTRY
 
 log = get_logger()
 
-# Non-TTY runs (CI) get a heartbeat line every N games instead of a tqdm bar.
+# Non-TTY runs (CI) get a heartbeat line every N games instead of a progress bar.
 _PROGRESS_EVERY = 250
 
 
@@ -123,21 +121,31 @@ def build_season(
     frames: list[pl.DataFrame] = []
     missing = 0
     failed = 0
-    for n, gid in enumerate(tqdm(game_ids, desc=f"{dataset} {season}", disable=None), start=1):
+
+    def _read_reshape(gid: int):
         final = ingest.read_final(gid, raw_root=root)
         if final is None:
-            missing += 1
-            continue
+            return ("missing", None)
         try:
             frame = reshape(final, season=season, game_id=gid)
         except Exception as e:  # R tryCatch(...) -> NULL parity
             log.warning("%s %s: reshape failed for game %s: %s", dataset, season, gid, e)
+            return ("failed", None)
+        return ("ok", frame if (frame is not None and frame.height) else None)
+
+    # Fan the per-game reads+reshapes out over a thread pool -- the reads are
+    # I/O-bound (HTTP in CI), so this is the difference between a minutes-long
+    # and a tens-of-minutes-long season. Results come back in game_ids order,
+    # so the concat + stable sort below stay byte-identical to the serial build.
+    for n, (status, frame) in enumerate(ingest.parallel_map(_read_reshape, game_ids), start=1):
+        if status == "missing":
+            missing += 1
+        elif status == "failed":
             failed += 1
-            continue
-        if frame is not None and frame.height:
+        elif frame is not None:
             frames.append(frame)
-        if not sys.stderr.isatty() and n % _PROGRESS_EVERY == 0:
-            log.info("%s %s: %d/%d games processed", dataset, season, n, len(game_ids))
+        if n % _PROGRESS_EVERY == 0:
+            log.info("%s %s: %d/%d games collected", dataset, season, n, len(game_ids))
     if missing:
         log.warning(
             "%s %s: %d/%d games had no readable payload", dataset, season, missing, len(game_ids)

--- a/python/wnba_data_build/ingest.py
+++ b/python/wnba_data_build/ingest.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import io
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import polars as pl
@@ -28,6 +29,32 @@ import polars as pl
 from wnba_data_build.config import RAW_ROOT_ENV
 
 _RAW_REPO_API = "https://api.github.com/repos/sportsdataverse/wehoop-wnba-raw/contents"
+
+
+def build_workers() -> int:
+    """Thread-pool size for the per-game/per-entity read+reshape fan-out.
+
+    The reads are I/O-bound (HTTP over raw.githubusercontent, or disk), so a
+    thread pool overlaps them -- the dominant cost of an HTTP-mode CI build.
+    Tunable via ``WEHOOP_WNBA_BUILD_WORKERS`` (default 16).
+    """
+    try:
+        return max(1, int(os.environ.get("WEHOOP_WNBA_BUILD_WORKERS", "16")))
+    except ValueError:
+        return 16
+
+
+def parallel_map(fn, items):
+    """Map ``fn`` over ``items`` with a thread pool; results in INPUT order.
+
+    Input-order results keep the downstream ``concat`` (+ its stable sort)
+    byte-identical to the sequential build -- parallelism is a pure speedup.
+    """
+    items = list(items)
+    if len(items) <= 1:
+        return [fn(x) for x in items]
+    with ThreadPoolExecutor(max_workers=min(build_workers(), len(items))) as ex:
+        return list(ex.map(fn, items))
 
 
 def _resolve_root(explicit: str | Path | None) -> Path | str:

--- a/python/wnba_data_build/reshapers.py
+++ b/python/wnba_data_build/reshapers.py
@@ -117,24 +117,35 @@ def shots_builder(season: int, *, raw_root: Path, base: Path) -> pl.DataFrame:
     return shots_from_pbp(pl.read_parquet(p))
 
 
-def _sidecar_builder(subdir: str, helper) -> object:
-    """Per-game sidecar loop (R scripts 08/09): completed games, tryCatch skips."""
+def _sidecar_builder(subdir: str, helper, *, fallback_subdir: str | None = None) -> object:
+    """Per-game sidecar loop (R scripts 08/09): completed games, tryCatch skips.
+
+    ``fallback_subdir`` recovers a game from a second raw location when the
+    primary sidecar is absent. Purely additive -- for a game whose primary
+    sidecar exists the fallback never fires, so current-season output is
+    unchanged.
+    """
 
     def _build(season: int, *, raw_root: Path, base: Path) -> pl.DataFrame:
         from wnba_data_build import ingest
 
-        frames: list[pl.DataFrame] = []
-        for gid in ingest.season_completed_game_ids(season, raw_root=raw_root):
+        def _one(gid: int) -> pl.DataFrame | None:
             payload = ingest.read_final(gid, raw_root=raw_root, subdir=subdir)
+            if payload is None and fallback_subdir is not None:
+                payload = ingest.read_final(gid, raw_root=raw_root, subdir=fallback_subdir)
             if payload is None:
-                continue
+                return None
             try:
                 frame = helper(payload, season=season, game_id=gid)
             except Exception as e:  # R tryCatch(...) -> NULL parity
                 log.warning("%s: parse failed for game %s: %s", subdir, gid, e)
-                continue
-            if frame.height:
-                frames.append(frame)
+                return None
+            return frame if frame.height else None
+
+        # Thread-pooled reads (I/O-bound HTTP in CI); input-order results keep
+        # the concat byte-identical to the serial build.
+        gids = ingest.season_completed_game_ids(season, raw_root=raw_root)
+        frames = [f for f in ingest.parallel_map(_one, gids) if f is not None]
         if not frames:
             return pl.DataFrame()
         return pl.concat(frames, how="diagonal_relaxed")
@@ -145,12 +156,20 @@ def _sidecar_builder(subdir: str, helper) -> object:
 def _game_rosters_builder() -> object:
     from sportsdataverse.wnba import helper_wnba_game_rosters
 
-    return _sidecar_builder("game_rosters/json", helper_wnba_game_rosters)
+    # game_rosters/json is a recent-only scrape (747 games); the same roster
+    # is byte-identical in the processed json/final summary (5838 games --
+    # verified across all 747 overlapping games, zero divergence), so fall
+    # back there to recover historical seasons with zero extra HTTP.
+    return _sidecar_builder(
+        "game_rosters/json", helper_wnba_game_rosters, fallback_subdir="json/final"
+    )
 
 
 def _officials_builder() -> object:
     from sportsdataverse.wnba import helper_wnba_officials
 
+    # WNBA has its own wnba/officials/ raw dir (unlike MBB/NBA) -- no
+    # json/final fallback here.
     return _sidecar_builder("officials/json", helper_wnba_officials)
 
 
@@ -160,19 +179,20 @@ def _per_entity_frames(
     """R scripts 04/05/06: loop the season's per-entity JSONs, tryCatch skips."""
     from wnba_data_build import ingest
 
-    frames: list[pl.DataFrame] = []
-    for eid in ingest.season_dir_ids(subdir, season, raw_root=raw_root):
+    def _one(eid: int) -> pl.DataFrame | None:
         payload = ingest.read_final(eid, raw_root=raw_root, subdir=f"{subdir}/json/{season}")
         if payload is None:
-            continue
+            return None
         try:
             frame = helper(payload, **{"season": season, id_kw: eid})
         except Exception as e:  # R tryCatch(...) -> NULL parity
             log.warning("%s: parse failed for entity %s: %s", subdir, eid, e)
-            continue
-        if frame.height:
-            frames.append(frame)
-    return frames
+            return None
+        return frame if frame.height else None
+
+    # Thread-pooled reads; input-order results keep _season_concat deterministic.
+    eids = ingest.season_dir_ids(subdir, season, raw_root=raw_root)
+    return [f for f in ingest.parallel_map(_one, eids) if f is not None]
 
 
 def _season_concat(frames: list[pl.DataFrame]) -> pl.DataFrame:
@@ -203,10 +223,12 @@ def player_season_stats_builder(season: int, *, raw_root: Path, base: Path) -> p
 
     from wnba_data_build import ingest
 
-    rosters = {
-        tid: ingest.read_final(tid, raw_root=raw_root, subdir=f"team_rosters/json/{season}")
-        for tid in ingest.season_dir_ids("team_rosters", season, raw_root=raw_root)
-    }
+    team_ids = ingest.season_dir_ids("team_rosters", season, raw_root=raw_root)
+
+    def _read_roster(tid: int):
+        return tid, ingest.read_final(tid, raw_root=raw_root, subdir=f"team_rosters/json/{season}")
+
+    rosters = dict(ingest.parallel_map(_read_roster, team_ids))
     lookup = build_athlete_identity_lookup({t: r for t, r in rosters.items() if r})
 
     def _helper(payload: dict, *, season: int, athlete_id: int) -> pl.DataFrame:


### PR DESCRIPTION
Mirrors the merged MBB/NBA cutover work, bringing `wnba_data_build` to parity with it.

## Parallelism
`ingest.parallel_map` / `build_workers` (env `WEHOOP_WNBA_BUILD_WORKERS`, default 16), wired into **every** per-item read site: `build_season`'s per-game loop, `_sidecar_builder`, `_per_entity_frames`, and `player_season_stats_builder`'s team-roster identity read. Results come back in **input order** (`ThreadPoolExecutor.map`), so the downstream concat + stable sort stay byte-identical to the serial build — parallelism is a pure speedup. This is what makes an HTTP-mode daily CI build viable.

## game_rosters REPOINT (zero-HTTP historical backfill)
`game_rosters` now falls back to `json/final` when the recent-only `game_rosters/json` sidecar is absent. **Verified across ALL 747 overlapping games: zero divergence** (identical shape, columns, values) — cleaner than the MBB precedent, which had one cosmetic name-format row. Purely additive: current seasons keep using `game_rosters/json`.

**officials deliberately untouched** — unlike MBB/NBA, WNBA has its own `wnba/officials/json` raw dir, so officials don't derive from game_rosters and get no fallback (their backfill is Phase-C scraping).

Parity suite: **61 passed**. ruff clean.