### PR TITLE
fix(ci): crosswalk failures are best-effort, not season-fatal

### DIFF
--- a/scripts/daily_wnba_data_processor.sh
+++ b/scripts/daily_wnba_data_processor.sh
@@ -62,9 +62,11 @@ for i in $(seq "${START_YEAR}" "${END_YEAR}"); do
 
     for SCRIPT in "${R_CROSSWALKS[@]}"; do
       echo "::group::$SCRIPT $i"
-      Rscript "$SCRIPT" -s "$i" -e "$i" || {
-        rc=$?; echo "::warning ::$SCRIPT for season $i exited with code $rc"; SEASON_RC=$rc
-      }
+      # Crosswalks build from LIVE ESPN+Torvik+Fox sources and are known-fragile
+      # (segfault/timeout on external flakiness). Best-effort: warn only, do NOT
+      # flip SEASON_RC -- the 11 core python datasets are the daily deliverable
+      # and must not be reported as failed because of a live external source.
+      Rscript "$SCRIPT" -s "$i" -e "$i" || echo "::warning ::$SCRIPT for season $i exited with code $? (crosswalk; non-fatal, live external source)"
       echo "::endgroup::"
     done
 


### PR DESCRIPTION
The daily processor's R crosswalk loop set `SEASON_RC` on failure, so a hiccup in `wnba_11/12/13_*_creation.R` — which build from **live external sources** and are known to segfault/timeout — failed the whole season's run even when all 11 core python datasets had built and published fine.

Warn instead, matching `hoopR-mbb-data` and `wehoop-wbb-data` (WBB was already warn-only; WNBA was the outlier). The python datasets are the daily deliverable and publish independently before the crosswalks run.

`bash -n` clean; workflow YAML unchanged.