### PR TITLE
feat(ci): add a use_python_build rollback gate to the daily workflow

### DIFF
--- a/.github/workflows/daily_wnba.yml
+++ b/.github/workflows/daily_wnba.yml
@@ -16,6 +16,11 @@ on:
       end_year:
         required: false
         type: string
+      use_python_build:
+        required: false
+        description: "Use the python wnba_data_build processor (default). Set false to roll back to the R processor."
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -99,4 +104,11 @@ jobs:
           SPORTSDATAVERSE.UPLOAD.QUIET: FALSE
           SPORTSDATAVERSE.UPLOAD.MAX_TIMES: 20
         run: |
-          bash scripts/daily_wnba_data_processor.sh -s ${{ env.START_YEAR }} -e ${{ env.END_YEAR }}
+          # Python is the production default (unchanged). use_python_build=false
+          # rolls back to the R processor -- kept in-repo for exactly this purpose.
+          # Cron / repository_dispatch pass no inputs, so they take the python path.
+          if [ "${{ inputs.use_python_build }}" = "false" ]; then
+            bash scripts/daily_wnba_R_processor.sh -s ${{ env.START_YEAR }} -e ${{ env.END_YEAR }}
+          else
+            bash scripts/daily_wnba_data_processor.sh -s ${{ env.START_YEAR }} -e ${{ env.END_YEAR }}
+          fi


### PR DESCRIPTION
The daily cron calls `daily_wnba_data_processor.sh` (python) unconditionally, so rolling back to R means editing + pushing the workflow under pressure. This adds the kill-switch that `hoopR-mbb-data`/`hoopR-nba-data` already have.

- New `use_python_build` `workflow_dispatch` input (**default `true`**) + a run-step selector.
- **Behavior unchanged**: cron and `repository_dispatch` pass no inputs, so they take the python path exactly as today.
- `use_python_build=false` dispatches the existing `scripts/daily_wnba_R_processor.sh`, which was sitting orphaned in-repo — this re-wires it as a selectable rollback instead of dead code.

Workflow YAML parses; default path verified as python.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional workflow setting to choose between Python and R data processing.
  * Python processing remains the default for manually triggered, scheduled, and event-based updates.
  * Manual runs can now select the R processing path when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->