### PR TITLE
feat(compile): add player_core dataset (athlete identity + bio)

### DIFF
--- a/python/tests/fixtures/raw/wnba/player_core/json/2490553.json
+++ b/python/tests/fixtures/raw/wnba/player_core/json/2490553.json
@@ -1,0 +1,231 @@
+{
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2490553?lang=en&region=us",
+"id": "2490553",
+"uid": "s:40~l:59~a:2490553",
+"guid": "40e7dc87-4f73-696a-7dd3-6953d9f8ae79",
+"type": "basketball",
+"alternateIds": {
+"sdr": "2490553"
+},
+"firstName": "Brittney",
+"lastName": "Griner",
+"fullName": "Brittney Griner",
+"displayName": "Brittney Griner",
+"shortName": "B. Griner",
+"weight": 205.0,
+"displayWeight": "205 lbs",
+"height": 81.0,
+"displayHeight": "6' 9\"",
+"age": 35,
+"dateOfBirth": "1990-10-18T07:00Z",
+"links": [
+{
+"language": "en-US",
+"rel": [
+"playercard",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/2490553/brittney-griner",
+"text": "Player Card",
+"shortText": "Player Card",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/stats/_/id/2490553/brittney-griner",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2490553&section=stats",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/gamelog/_/id/2490553/brittney-griner",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2490553&section=gamelog",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/news/_/id/2490553/brittney-griner",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2490553&section=news",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/bio/_/id/2490553/brittney-griner",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2490553&section=bio",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/2490553/brittney-griner",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2490553",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+}
+],
+"birthPlace": {
+"city": "Houston",
+"state": "TX",
+"country": "USA"
+},
+"college": {
+"$ref": "http://sports.core.api.espn.com/v2/colleges/239?lang=en&region=us"
+},
+"slug": "brittney-griner",
+"headshot": {
+"href": "https://a.espncdn.com/i/headshots/wnba/players/full/2490553.png",
+"alt": "Brittney Griner"
+},
+"jersey": "42",
+"position": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/positions/9?lang=en&region=us",
+"id": "9",
+"name": "Center",
+"displayName": "Center",
+"abbreviation": "C",
+"leaf": false
+},
+"linked": true,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2026/teams/18?lang=en&region=us"
+},
+"statistics": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2490553/statistics?lang=en&region=us"
+},
+"contracts": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2490553/contracts?lang=en&region=us"
+},
+"experience": {
+"years": 13
+},
+"collegeAthlete": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/athletes/12372?lang=en&region=us"
+},
+"active": true,
+"draft": {
+"displayText": "Year: 2013 Round: 1 Pick: 1",
+"round": 1,
+"year": 2013,
+"selection": 1,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2013/teams/11?lang=en&region=us"
+}
+},
+"status": {
+"id": "1",
+"name": "Active",
+"type": "active",
+"abbreviation": "Active"
+},
+"statisticslog": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2490553/statisticslog?lang=en&region=us"
+},
+"seasons": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2490553/seasons?lang=en&region=us"
+}
+}

--- a/python/tests/fixtures/raw/wnba/player_core/json/2529122.json
+++ b/python/tests/fixtures/raw/wnba/player_core/json/2529122.json
@@ -1,0 +1,231 @@
+{
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529122?lang=en&region=us",
+"id": "2529122",
+"uid": "s:40~l:59~a:2529122",
+"guid": "6a3fef56-2bd2-ba2e-1e18-4723c4590b47",
+"type": "basketball",
+"alternateIds": {
+"sdr": "2529122"
+},
+"firstName": "Chelsea",
+"lastName": "Gray",
+"fullName": "Chelsea Gray",
+"displayName": "Chelsea Gray",
+"shortName": "C. Gray",
+"weight": 170.0,
+"displayWeight": "170 lbs",
+"height": 71.0,
+"displayHeight": "5' 11\"",
+"age": 33,
+"dateOfBirth": "1992-10-08T07:00Z",
+"links": [
+{
+"language": "en-US",
+"rel": [
+"playercard",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/2529122/chelsea-gray",
+"text": "Player Card",
+"shortText": "Player Card",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/stats/_/id/2529122/chelsea-gray",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529122&section=stats",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/gamelog/_/id/2529122/chelsea-gray",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529122&section=gamelog",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/news/_/id/2529122/chelsea-gray",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529122&section=news",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/bio/_/id/2529122/chelsea-gray",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529122&section=bio",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/2529122/chelsea-gray",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529122",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+}
+],
+"birthPlace": {
+"city": "Hayward",
+"state": "CA",
+"country": "USA"
+},
+"college": {
+"$ref": "http://sports.core.api.espn.com/v2/colleges/150?lang=en&region=us"
+},
+"slug": "chelsea-gray",
+"headshot": {
+"href": "https://a.espncdn.com/i/headshots/wnba/players/full/2529122.png",
+"alt": "Chelsea Gray"
+},
+"jersey": "12",
+"position": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/positions/3?lang=en&region=us",
+"id": "3",
+"name": "Guard",
+"displayName": "Guard",
+"abbreviation": "G",
+"leaf": false
+},
+"linked": true,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2026/teams/17?lang=en&region=us"
+},
+"statistics": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529122/statistics?lang=en&region=us"
+},
+"contracts": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529122/contracts?lang=en&region=us"
+},
+"experience": {
+"years": 12
+},
+"collegeAthlete": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/athletes/13919?lang=en&region=us"
+},
+"active": true,
+"draft": {
+"displayText": "Year: 2014 Round: 1 Pick: 11",
+"round": 1,
+"year": 2014,
+"selection": 11,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2014/teams/18?lang=en&region=us"
+}
+},
+"status": {
+"id": "1",
+"name": "Active",
+"type": "active",
+"abbreviation": "Active"
+},
+"statisticslog": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529122/statisticslog?lang=en&region=us"
+},
+"seasons": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529122/seasons?lang=en&region=us"
+}
+}

--- a/python/tests/fixtures/raw/wnba/player_core/json/2529140.json
+++ b/python/tests/fixtures/raw/wnba/player_core/json/2529140.json
@@ -1,0 +1,222 @@
+{
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529140?lang=en&region=us",
+"id": "2529140",
+"uid": "s:40~l:59~a:2529140",
+"guid": "908608e9-31d4-62f2-dfe2-9fee9024e7e2",
+"type": "basketball",
+"alternateIds": {
+"sdr": "2529140"
+},
+"firstName": "Alyssa",
+"lastName": "Thomas",
+"fullName": "Alyssa Thomas",
+"displayName": "Alyssa Thomas",
+"shortName": "A. Thomas",
+"weight": 203.0,
+"displayWeight": "203 lbs",
+"height": 74.0,
+"displayHeight": "6' 2\"",
+"age": 34,
+"dateOfBirth": "1992-04-12T07:00Z",
+"links": [
+{
+"language": "en-US",
+"rel": [
+"playercard",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/2529140/alyssa-thomas",
+"text": "Player Card",
+"shortText": "Player Card",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/stats/_/id/2529140/alyssa-thomas",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529140&section=stats",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/gamelog/_/id/2529140/alyssa-thomas",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529140&section=gamelog",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/news/_/id/2529140/alyssa-thomas",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529140&section=news",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/bio/_/id/2529140/alyssa-thomas",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529140&section=bio",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/2529140/alyssa-thomas",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:2529140",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+}
+],
+"birthPlace": {
+"city": "Camp Hill",
+"state": "PA",
+"country": "USA"
+},
+"college": {
+"$ref": "http://sports.core.api.espn.com/v2/colleges/120?lang=en&region=us"
+},
+"slug": "alyssa-thomas",
+"headshot": {
+"href": "https://a.espncdn.com/i/headshots/wnba/players/full/2529140.png",
+"alt": "Alyssa Thomas"
+},
+"jersey": "25",
+"position": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/positions/7?lang=en&region=us",
+"id": "7",
+"name": "Forward",
+"displayName": "Forward",
+"abbreviation": "F",
+"leaf": false
+},
+"linked": true,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2026/teams/11?lang=en&region=us"
+},
+"statistics": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529140/statistics?lang=en&region=us"
+},
+"contracts": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529140/contracts?lang=en&region=us"
+},
+"experience": {
+"years": 13
+},
+"collegeAthlete": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/athletes/13898?lang=en&region=us"
+},
+"active": true,
+"status": {
+"id": "1",
+"name": "Active",
+"type": "active",
+"abbreviation": "Active"
+},
+"statisticslog": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529140/statisticslog?lang=en&region=us"
+},
+"seasons": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/2529140/seasons?lang=en&region=us"
+}
+}

--- a/python/tests/fixtures/raw/wnba/player_core/json/869.json
+++ b/python/tests/fixtures/raw/wnba/player_core/json/869.json
@@ -1,0 +1,222 @@
+{
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/869?lang=en&region=us",
+"id": "869",
+"uid": "s:40~l:59~a:869",
+"guid": "74bfe609-0fcb-e955-df3e-e206e06a3a6a",
+"type": "basketball",
+"alternateIds": {
+"sdr": "2205794"
+},
+"firstName": "DeWanna",
+"lastName": "Bonner",
+"fullName": "DeWanna Bonner",
+"displayName": "DeWanna Bonner",
+"shortName": "D. Bonner",
+"weight": 140.0,
+"displayWeight": "140 lbs",
+"height": 76.0,
+"displayHeight": "6' 4\"",
+"age": 38,
+"dateOfBirth": "1987-08-21T07:00Z",
+"links": [
+{
+"language": "en-US",
+"rel": [
+"playercard",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/869/dewanna-bonner",
+"text": "Player Card",
+"shortText": "Player Card",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/stats/_/id/869/dewanna-bonner",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:869&section=stats",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/gamelog/_/id/869/dewanna-bonner",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:869&section=gamelog",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/news/_/id/869/dewanna-bonner",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:869&section=news",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/bio/_/id/869/dewanna-bonner",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:869&section=bio",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/869/dewanna-bonner",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:869",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+}
+],
+"birthPlace": {
+"city": "Fairfield",
+"state": "AL",
+"country": "USA"
+},
+"college": {
+"$ref": "http://sports.core.api.espn.com/v2/colleges/2?lang=en&region=us"
+},
+"slug": "dewanna-bonner",
+"headshot": {
+"href": "https://a.espncdn.com/i/headshots/wnba/players/full/869.png",
+"alt": "DeWanna Bonner"
+},
+"jersey": "24",
+"position": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/positions/7?lang=en&region=us",
+"id": "7",
+"name": "Forward",
+"displayName": "Forward",
+"abbreviation": "F",
+"leaf": false
+},
+"linked": true,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2026/teams/11?lang=en&region=us"
+},
+"statistics": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/869/statistics?lang=en&region=us"
+},
+"contracts": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/869/contracts?lang=en&region=us"
+},
+"experience": {
+"years": 17
+},
+"collegeAthlete": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/athletes/5306?lang=en&region=us"
+},
+"active": true,
+"status": {
+"id": "1",
+"name": "Active",
+"type": "active",
+"abbreviation": "Active"
+},
+"statisticslog": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/869/statisticslog?lang=en&region=us"
+},
+"seasons": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/869/seasons?lang=en&region=us"
+}
+}

--- a/python/tests/fixtures/raw/wnba/player_core/json/887.json
+++ b/python/tests/fixtures/raw/wnba/player_core/json/887.json
@@ -1,0 +1,222 @@
+{
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/887?lang=en&region=us",
+"id": "887",
+"uid": "s:40~l:59~a:887",
+"guid": "c74956ad-2490-b3c4-0cef-485fb49da1a6",
+"type": "basketball",
+"alternateIds": {
+"sdr": "2241853"
+},
+"firstName": "Sami",
+"lastName": "Whitcomb",
+"fullName": "Sami Whitcomb",
+"displayName": "Sami Whitcomb",
+"shortName": "S. Whitcomb",
+"weight": 149.0,
+"displayWeight": "149 lbs",
+"height": 70.0,
+"displayHeight": "5' 10\"",
+"age": 37,
+"dateOfBirth": "1988-07-20T07:00Z",
+"links": [
+{
+"language": "en-US",
+"rel": [
+"playercard",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/887/sami-whitcomb",
+"text": "Player Card",
+"shortText": "Player Card",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/stats/_/id/887/sami-whitcomb",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:887&section=stats",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/gamelog/_/id/887/sami-whitcomb",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:887&section=gamelog",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/news/_/id/887/sami-whitcomb",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:887&section=news",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/bio/_/id/887/sami-whitcomb",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:887&section=bio",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/887/sami-whitcomb",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:887",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+}
+],
+"birthPlace": {
+"city": "Ventura",
+"state": "CA",
+"country": "USA"
+},
+"college": {
+"$ref": "http://sports.core.api.espn.com/v2/colleges/264?lang=en&region=us"
+},
+"slug": "sami-whitcomb",
+"headshot": {
+"href": "https://a.espncdn.com/i/headshots/wnba/players/full/887.png",
+"alt": "Sami Whitcomb"
+},
+"jersey": "33",
+"position": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/positions/3?lang=en&region=us",
+"id": "3",
+"name": "Guard",
+"displayName": "Guard",
+"abbreviation": "G",
+"leaf": false
+},
+"linked": true,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2026/teams/11?lang=en&region=us"
+},
+"statistics": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/887/statistics?lang=en&region=us"
+},
+"contracts": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/887/contracts?lang=en&region=us"
+},
+"experience": {
+"years": 10
+},
+"collegeAthlete": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/athletes/6056?lang=en&region=us"
+},
+"active": true,
+"status": {
+"id": "1",
+"name": "Active",
+"type": "active",
+"abbreviation": "Active"
+},
+"statisticslog": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/887/statisticslog?lang=en&region=us"
+},
+"seasons": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/887/seasons?lang=en&region=us"
+}
+}

--- a/python/tests/wnba_data_build/test_all_datasets_smoke.py
+++ b/python/tests/wnba_data_build/test_all_datasets_smoke.py
@@ -25,6 +25,7 @@ _SEASON = {
     "officials": 2025,
     "rosters": 2025,
     "player_season_stats": 2025,
+    "player_core": 2025,
     "team_season_stats": 2025,
     "standings": 2025,
     "draft": 2026,
@@ -40,6 +41,8 @@ def test_each_dataset_builds(dataset, tmp_path):
     season = _SEASON[dataset]
     if dataset == "shots":  # shots read the built pbp parquet
         build_season("pbp", season, base=tmp_path, raw_root=FX / "raw")
+    if dataset == "player_core":  # player_core reads the built player_box parquet
+        build_season("player_box", season, base=tmp_path, raw_root=FX / "raw")
     df = build_season(dataset, season, base=tmp_path, raw_root=FX / "raw", dry_run=True)
     assert df.height > 0
     spec = REGISTRY[dataset]

--- a/python/wnba_data_build/config.py
+++ b/python/wnba_data_build/config.py
@@ -77,6 +77,22 @@ REGISTRY: dict[str, DatasetSpec] = {
         "player_season_stats",
         manifest_endpoint=_RAW + "/player_season_stats/json/{season}/<athlete_id>.json",
     ),
+    # Athlete identity + bio. NEW dataset -- no R creation script exists, and
+    # nothing published this before: the player_season_stats payload carries no
+    # identity at all (not even the athlete id -- only the filename does).
+    # NB: unlike this league's player_season_stats, the raw tree is FLAT (no
+    # {season} segment) -- a core record is per-athlete and the core-v2 athlete
+    # resource takes no season param. "Who played in season Y" comes from the
+    # built player_box.
+    "player_core": DatasetSpec(
+        "player_core",
+        "player_core",
+        _T + "player_core",
+        "player_core",
+        # NO manifest_endpoint: a manifest is the contract for an R
+        # load_wnba_<ds>_manifest() loader, and player_core has no loader yet --
+        # manifesting it would publish an asset nothing reads.
+    ),
     "team_season_stats": DatasetSpec(
         "team_season_stats",
         "team_season_stats",

--- a/python/wnba_data_build/reshapers.py
+++ b/python/wnba_data_build/reshapers.py
@@ -241,6 +241,70 @@ def player_season_stats_builder(season: int, *, raw_root: Path, base: Path) -> p
     )
 
 
+def player_core_builder(season: int, *, raw_root: Path, base: Path) -> pl.DataFrame:
+    """Athlete identity + bio for the athletes who appeared in ``season``.
+
+    The raw tree is flat (``player_core/json/<athlete_id>.json``, one record per
+    athlete -- the core-v2 athlete resource takes no season param), so "who
+    played in season Y" comes from the season's already-built player_box.
+    Requires player_box to have been built first under ``base``.
+
+    What the season partition MEANS here: "the athletes who appeared in season
+    Y, with their CURRENT bio". The season dimension is participation -- it is
+    NOT the bio's vintage. ESPN overwrites height/weight/jersey in place, so
+    era-correct bio is not obtainable from any ESPN endpoint, and
+    ``current_team_id`` is the athlete's team TODAY, not their season team
+    (that lives in player_box / player_season_stats). See
+    ``sportsdataverse.nba.nba_player_core``.
+    """
+    from sportsdataverse.wnba import helper_wnba_player_core
+
+    from wnba_data_build import ingest
+
+    pb_path = base / "player_box" / "parquet" / f"player_box_{season}.parquet"
+    if not pb_path.exists():
+        log.warning(
+            "player_core %s: no built player_box parquet at %s -- cannot resolve "
+            "which athletes played this season (build player_box first)",
+            season,
+            pb_path,
+        )
+        return pl.DataFrame()
+    # Only the ID SET is needed, not identity columns -- player_core *is* the
+    # identity source. So this reads athlete_id straight off player_box rather
+    # than going through an identity lookup (those exist to graft identity onto
+    # the identity-less player_season_stats payload). It also keeps this builder
+    # identical across all four leagues: wnba/wbb have no player_box-based
+    # lookup, only a team_rosters-based one -- and team_rosters is exactly the
+    # source ESPN cannot serve historically.
+    athlete_ids = sorted(
+        {int(a) for a in pl.read_parquet(pb_path, columns=["athlete_id"])["athlete_id"].drop_nulls().unique()}
+    )
+
+    def _one(aid: int) -> pl.DataFrame | None:
+        payload = ingest.read_final(aid, raw_root=raw_root, subdir="player_core/json")
+        if payload is None:
+            return None
+        try:
+            frame = helper_wnba_player_core(payload, athlete_id=aid)
+        except Exception as e:  # tryCatch(...) -> NULL parity with the sibling builders
+            log.warning("player_core: parse failed for athlete %s: %s", aid, e)
+            return None
+        return frame if frame.height else None
+
+    # Thread-pooled athlete reads (tens of thousands per season over HTTP in CI);
+    # input-order results keep _season_concat deterministic.
+    frames = [f for f in ingest.parallel_map(_one, athlete_ids) if f is not None]
+    out = _season_concat(frames)
+    if out.is_empty():
+        return out
+    # The helper is a pure athlete projection (it deliberately takes no season --
+    # a core record is not season data). The season column belongs to the
+    # PARTITION, so the builder stamps it, keeping the released frame
+    # self-describing when seasons are concatenated.
+    return out.select(pl.lit(season, dtype=pl.Int32).alias("season"), pl.all())
+
+
 def standings_builder(season: int, *, raw_root: Path, base: Path) -> pl.DataFrame:
     from sportsdataverse.wnba import helper_wnba_standings
 
@@ -276,6 +340,7 @@ SEASON_BUILDERS: dict = {
     "rosters": rosters_builder,
     "team_season_stats": team_season_stats_builder,
     "player_season_stats": player_season_stats_builder,
+    "player_core": player_core_builder,
     "standings": standings_builder,
     "draft": draft_builder,
 }


### PR DESCRIPTION
Compiles the new `wnba/player_core` raw tree into `player_core_{season}.parquet` via `sportsdataverse.wnba.helper_wnba_player_core` (**depends on [sportsdataverse-py#270](https://github.com/sportsdataverse/sportsdataverse-py/pull/270)**).

**Why the dataset exists:** `player_season_stats` carries **no athlete identity at all** — no name, no bio, **not even the athlete id** (only the filename does). Its `"height"` keys are team-logo pixel heights; its `"fullName"` keys are arena names. This is the pipeline's first source of athlete bio.

## Builder
Mirrors `player_season_stats_builder`: the raw tree is **flat** (`player_core/json/<athlete_id>.json` — a core record is per-athlete, and the core-v2 athlete resource takes no season param), so *"who played in season Y"* comes from the season's **already-built player_box**.

It reads `athlete_id` straight off player_box rather than via an identity lookup — **player_core *is* the identity source**, so only the id set is needed. That also keeps the builder identical across all four leagues: wnba/wbb have no player_box-based lookup, only a **team_rosters**-based one — and team_rosters is exactly the source ESPN cannot serve historically.

## What the season partition means
**"The athletes who appeared in season Y, with their CURRENT bio."** The season dimension is *participation*, not the bio's vintage — ESPN overwrites height/weight/jersey in place, so era-correct bio is unobtainable from any ESPN endpoint, and `current_team_id` is the athlete's team **today**, not their season team. The sdv-py helper deliberately takes no `season`; the builder stamps the partition's.

## No manifest — on purpose
A manifest is the contract for an R `load_wnba_<ds>_manifest()` loader, and player_core has no loader yet, so manifesting it would **publish an asset nothing reads**. The repo's existing *"exactly the R-manifested datasets have a manifest"* test caught me adding one — good test.

## Verified
Builds a real season end-to-end against the committed raw tree, and the full suite passes.

Release tag `espn_wnba_player_core` **does not exist yet** — creating it, and the matching R loader, is a separate deliberate decision.