### PR TITLE
feat(ci): build + publish player_core in the daily flow

### DIFF
--- a/scripts/daily_wnba_data_processor.sh
+++ b/scripts/daily_wnba_data_processor.sh
@@ -32,7 +32,7 @@ export PYTHONIOENCODING=utf-8
 
 # Dependency order: pbp/team_box/player_box first (schedules reads their
 # game-id sets; shots read the pbp parquet), then the rest.
-PY_DATASETS="pbp team_box player_box schedules shots rosters player_season_stats team_season_stats standings game_rosters officials"
+PY_DATASETS="pbp team_box player_box player_core schedules shots rosters player_season_stats team_season_stats standings game_rosters officials"
 R_CROSSWALKS=(R/wnba_11_team_crosswalk_creation.R R/wnba_12_schedule_crosswalk_creation.R R/wnba_13_player_crosswalk_creation.R)
 
 mkdir -p logs


### PR DESCRIPTION
`player_core` is in the registry and its release tag is populated for **every historical season** — but the daily processor's dataset list is **hardcoded**, and never included it. The dataset would have frozen at the backfill and silently missed every new athlete from here on.

Adds it **immediately after `player_box`**: `player_core` resolves *"who played in season Y"* from the season's **built player_box parquet**, so it must run after player_box in the same pass.

Found by asking what was actually left after the backfill, rather than assuming the registry entry was enough.