### PR TITLE
feat(compile): serialize player_core to .rds

### DIFF
--- a/R/serialize_rds.R
+++ b/R/serialize_rds.R
@@ -94,6 +94,7 @@ DATASETS <- list(
   list("player_box",          "player_box",          paste0(T_, "player_boxscores"),    "wehoop::load_wnba_player_box()"),
   list("rosters",             "rosters",             paste0(T_, "rosters"),             "wehoop::load_wnba_rosters()"),
   list("player_season_stats", "player_season_stats", paste0(T_, "player_season_stats"), "wehoop::load_wnba_player_stats()"),
+  list("player_core",         "player_core",         paste0(T_, "player_core"),         "wehoop::load_wnba_player_core()"),
   list("team_season_stats",   "team_season_stats",   paste0(T_, "team_season_stats"),   "wehoop::load_wnba_team_stats()"),
   list("standings",           "standings",           paste0(T_, "standings"),           "wehoop::load_wnba_standings()"),
   list("game_rosters",        "game_rosters",        paste0(T_, "game_rosters"),        "wehoop::load_wnba_game_rosters()"),


### PR DESCRIPTION
`wehoop::load_wnba_*` reads **`.rds`**, and `player_core`'s release shipped parquet+csv but **no rds at all** — so the dataset would be unreachable through the loader surface even once a loader exists.

`serialize_rds.R`'s `DATASETS` list is **hardcoded** (it mirrors the registry by hand), so a new dataset doesn't appear automatically. Adds `player_core` after `player_season_stats`.

Unlike the NBA/MBB siblings ([hoopR-nba-data#10](https://github.com/sportsdataverse/hoopR-nba-data/pull/10)), **this repo never lost the serialize step** — its processor has always run `serialize_rds.R`, which is why its rds stayed in sync with the parquet through the python cutover.