### PR TITLE
fix(publish): fail loudly on non-404 release-view errors + tolerate create races

### DIFF
--- a/python/wnba_data_build/publish.py
+++ b/python/wnba_data_build/publish.py
@@ -34,18 +34,29 @@ log = get_logger()
 
 
 def _gh(args: list[str]) -> None:
-    subprocess.run(["gh", *args], check=True)
+    subprocess.run(["gh", *args], check=True, stderr=subprocess.PIPE, text=True)
 
 
 def _gh_release_exists(tag: str, repo: str) -> bool:
-    return (
-        subprocess.run(
-            ["gh", "release", "view", tag, "--repo", repo],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        ).returncode
-        == 0
+    """True when ``tag`` exists on ``repo``.
+
+    Only a genuine "not found" answer from ``gh`` counts as absence -- a rate
+    limit / auth / network failure must never be read as "release missing"
+    (that misreading is what makes the caller run ``release create`` on a tag
+    that already exists and crash the whole publish run).
+    """
+    proc = subprocess.run(
+        ["gh", "release", "view", tag, "--repo", repo],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
     )
+    if proc.returncode == 0:
+        return True
+    stderr = (proc.stderr or "").strip()
+    if "release not found" in stderr.lower():
+        return False
+    raise RuntimeError(f"gh release view {tag} --repo {repo} failed: {stderr}")
 
 
 def _manifest_asset(spec: DatasetSpec, base: Path) -> Path | None:
@@ -143,19 +154,28 @@ def publish_dataset(
         log.warning("%s %s: no files to publish under %s", spec.dataset, season, base)
     if not dry_run and not exists(spec.tag, repo):
         log.info("release %s missing on %s -- creating it", spec.tag, repo)
-        run(
-            [
-                "release",
-                "create",
-                spec.tag,
-                "--repo",
-                repo,
-                "--title",
-                spec.tag,
-                "--notes",
-                f"{spec.tag} (WNBA dataset, Python-built).",
-            ]
-        )
+        try:
+            run(
+                [
+                    "release",
+                    "create",
+                    spec.tag,
+                    "--repo",
+                    repo,
+                    "--title",
+                    spec.tag,
+                    "--notes",
+                    f"{spec.tag} (WNBA dataset, Python-built).",
+                ]
+            )
+        except subprocess.CalledProcessError as exc:
+            # Belt-and-suspenders for the race exists() didn't catch (e.g. a
+            # concurrent run created the tag between the check and here).
+            stderr = (exc.stderr or "").lower() if isinstance(exc.stderr, str) else ""
+            if "already exists" in stderr:
+                log.info("release %s already exists on %s -- continuing", spec.tag, repo)
+            else:
+                raise
     count = 0
     for f in files:
         size = human_size(f.stat().st_size)

--- a/tests/wnba_data_build/test_publish.py
+++ b/tests/wnba_data_build/test_publish.py
@@ -1,6 +1,8 @@
+import subprocess
 from pathlib import Path
 
 import polars as pl
+import pytest
 from wnba_data_build import io, publish
 from wnba_data_build.config import REGISTRY
 
@@ -78,3 +80,56 @@ def test_publish_creates_release_when_missing(tmp_path):
         exists_check=lambda tag, repo: False,
     )
     assert any(c[:2] == ["release", "create"] for c in calls)
+
+
+def test_gh_release_exists_true_on_zero_exit(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(publish.subprocess, "run", fake_run)
+    assert publish._gh_release_exists("tag", "repo") is True
+
+
+def test_gh_release_exists_false_on_genuine_not_found(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="release not found")
+
+    monkeypatch.setattr(publish.subprocess, "run", fake_run)
+    assert publish._gh_release_exists("tag", "repo") is False
+
+
+def test_gh_release_exists_raises_loudly_on_other_failure(monkeypatch):
+    # Regression: a rate-limit / auth / network failure must never be read as
+    # "release missing" -- that's the 2026-08-23 incident (fail-open crashed
+    # a backfill mid-publish because `gh release create` ran on a live tag).
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="API rate limit exceeded")
+
+    monkeypatch.setattr(publish.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="rate limit"):
+        publish._gh_release_exists("tag", "repo")
+
+
+def test_publish_tolerates_create_race(tmp_path):
+    # exists() said missing, but the injected runner's create call races
+    # against a concurrent creator and gh reports "already exists" -- the
+    # publish must continue (log + proceed to upload), not crash.
+    spec = REGISTRY["team_box"]
+    io.write_dataset(pl.DataFrame({"game_id": [1]}), spec, 2025, base=tmp_path)
+    calls = []
+
+    def runner(args):
+        calls.append(args)
+        if args[:2] == ["release", "create"]:
+            raise subprocess.CalledProcessError(1, args, stderr="already exists")
+
+    res = publish.publish_dataset(
+        spec,
+        2025,
+        base=tmp_path,
+        runner=runner,
+        exists_check=lambda tag, repo: False,
+    )
+    uploads = [c for c in calls if c[:2] == ["release", "upload"]]
+    assert len(uploads) == 3
+    assert res["uploaded"] == 3


### PR DESCRIPTION
## Summary
- \`_gh_release_exists\` treated ANY non-zero \`gh release view\` exit as "release missing" (silent fail-open) -- the same defect that hit the wehoop-wbb-data sibling during a GitHub GraphQL rate-limit window on 2026-08-23, crashing a publish run mid-backfill by triggering \`gh release create\` on a tag that already existed.
- Now only a genuine "release not found" \`gh\` stderr counts as absence; any other failure (rate limit, auth, network) raises a \`RuntimeError\` naming the stderr instead of silently proceeding.
- Belt-and-suspenders: the \`release create\` call also tolerates an "already exists" race (a concurrent creator winning between the check and the create) by logging and continuing instead of crashing.
- Added unit tests for the true/false-not-found/raises-on-other-failure matrix and for the create-race tolerance, using the existing injectable \`runner\`/\`exists_check\` seams.

## Test plan
- [x] \`uv run pytest tests/wnba_data_build/test_publish.py -q\` -- 8 passed
- [x] \`uv run pytest -q\` (full suite) -- 118 passed, 3 skipped

## Summary by Sourcery

Prevent publish runs from misinterpreting GitHub API failures as missing releases and handle concurrent release creation safely.

Bug Fixes:
- Fail loudly when GitHub release lookup fails for reasons other than a genuine release-not-found response.
- Continue publishing when release creation loses a concurrent already-exists race.

Tests:
- Add coverage for successful lookups, genuine not-found responses, unexpected lookup failures, and release-creation races.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability by distinguishing missing releases from authentication, rate-limit, network, and other errors.
  * Prevented publishing failures when a release is created concurrently by another process.
  * Ensured unexpected GitHub errors are surfaced instead of being treated as missing releases.

* **Tests**
  * Added coverage for successful release checks, genuine not-found responses, unexpected failures, and concurrent creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->