### PR TITLE
feat(publish): stamp timestamp + package_function sidecars on every release update

### DIFF
--- a/python/wnba_data_build/config.py
+++ b/python/wnba_data_build/config.py
@@ -215,3 +215,32 @@ REGISTRY: dict[str, DatasetSpec] = {
         sdv_type="player crosswalk data",
     ),
 }
+
+
+# --- release sidecar metadata -------------------------------------------------
+# Every published tag carries package_function.txt/.json naming the loader a
+# consumer reaches the data through -- the half of R's sportsdataverse_save()
+# the Python publisher used to drop. Values are NOT invented: where the R
+# producer already published a package_function to the tag, that exact string
+# is reused, so re-stamping from Python does not change what a consumer sees.
+# Python-only tags that never had one name the sdv-py loader instead.
+#
+# Keyed by tag, not dataset -- several datasets can share one tag.
+# The publish tests assert every REGISTRY tag has an entry, so a new dataset
+# cannot ship an unnamed tag.
+PKG_FUNCTION: dict[str, str] = {
+    "espn_wnba_draft": "wehoop::load_wnba_draft()",
+    "espn_wnba_game_rosters": "wehoop::load_wnba_game_rosters()",
+    "espn_wnba_officials": "wehoop::load_wnba_officials()",
+    "espn_wnba_pbp": "wehoop::load_wnba_pbp()",
+    "espn_wnba_player_boxscores": "wehoop::load_wnba_player_box()",
+    "espn_wnba_player_core": "sportsdataverse.wnba.load_wnba_player_core()",
+    "espn_wnba_player_season_stats": "wehoop::load_wnba_player_stats()",
+    "espn_wnba_rosters": "wehoop::load_wnba_rosters_manifest()",
+    "espn_wnba_schedules": "wehoop::load_wnba_schedule()",
+    "espn_wnba_shots": "wehoop::load_wnba_pbp()",
+    "espn_wnba_standings": "wehoop::load_wnba_standings()",
+    "espn_wnba_team_boxscores": "wehoop::load_wnba_team_box()",
+    "espn_wnba_team_season_stats": "wehoop::load_wnba_team_stats()",
+    "wnba_crosswalk": "wehoop::wnba_player_crosswalk()",
+}

--- a/python/wnba_data_build/publish.py
+++ b/python/wnba_data_build/publish.py
@@ -21,10 +21,11 @@ from pathlib import Path
 from typing import Callable
 
 import polars as pl
+from sportsdataverse.release import upload_release_sidecars
 
 from wnba_data_build import io as build_io
 from wnba_data_build._logging import get_logger, human_size
-from wnba_data_build.config import DatasetSpec
+from wnba_data_build.config import PKG_FUNCTION, DatasetSpec
 
 _LEAGUE = "wnba"
 
@@ -116,6 +117,22 @@ def _dataset_files(spec: DatasetSpec, season: int, base: Path) -> list[Path]:
     return files
 
 
+def _stamp(tag: str, run: Callable[[list[str]], None], repo: str) -> None:
+    """Re-stamp a tag's timestamp / package_function sidecars after an upload.
+
+    R's sportsdataverse_save() attaches these to every published tag; the
+    Python publisher dropped them, which left the tag carrying a timestamp.json
+    frozen at the last R run while the data kept moving. Runs LAST so the stamp
+    reflects the finished upload, and only when something actually uploaded --
+    a stamp on a no-op run would claim data moved when it did not. Goes through
+    the same injected ``run`` as the data assets so tests stay offline.
+    """
+    uploaded = upload_release_sidecars(
+        tag, runner=run, pkg_function=PKG_FUNCTION.get(tag), repo=repo
+    )
+    log.info("stamped %s with %s", tag, ", ".join(uploaded))
+
+
 def publish_dataset(
     spec: DatasetSpec,
     season: int,
@@ -186,6 +203,8 @@ def publish_dataset(
         run(["release", "upload", spec.tag, str(f), "--repo", repo, "--clobber"])
         count += 1
         log.info("uploaded %s -> %s (asset %d/%d)", f.name, spec.tag, count, len(files))
+    if count:
+        _stamp(spec.tag, run, repo)
     return {"tag": spec.tag, "files": [str(f) for f in files], "uploaded": count}
 
 
@@ -225,4 +244,6 @@ def publish_files(
         run(["release", "upload", tag, str(f), "--repo", repo, "--clobber"])
         count += 1
         log.info("uploaded %s -> %s (asset %d/%d)", f.name, tag, count, len(files))
+    if count:
+        _stamp(tag, run, repo)
     return {"tag": tag, "files": [str(f) for f in files], "uploaded": count}

--- a/tests/wnba_data_build/test_publish.py
+++ b/tests/wnba_data_build/test_publish.py
@@ -6,6 +6,9 @@ import pytest
 from wnba_data_build import io, publish
 from wnba_data_build.config import REGISTRY
 
+#: release metadata sidecars -- asserted separately, not a data asset
+SIDECARS = ("timestamp.", "package_function.")
+
 
 def test_publish_uploads_each_file_with_clobber(tmp_path):
     spec = REGISTRY["team_box"]
@@ -18,7 +21,11 @@ def test_publish_uploads_each_file_with_clobber(tmp_path):
         runner=lambda args: calls.append(args),
         exists_check=lambda tag, repo: True,  # release already exists
     )
-    uploads = [c for c in calls if c[:2] == ["release", "upload"]]
+    uploads = [
+        c
+        for c in calls
+        if c[:2] == ["release", "upload"] and not Path(c[3]).name.startswith(SIDECARS)
+    ]
     # team_box is not manifested -> parquet + rds + csv. The tree csv is gzipped,
     # but the release asset contract is plain .csv (decompressed to a temp file).
     # rds is NOT optional: wehoop::load_wnba_* reads rds exclusively, so a
@@ -41,7 +48,11 @@ def test_publish_uploads_manifest_for_manifested_datasets(tmp_path):
         runner=lambda args: calls.append(args),
         exists_check=lambda tag, repo: True,
     )
-    uploads = [c for c in calls if c[:2] == ["release", "upload"]]
+    uploads = [
+        c
+        for c in calls
+        if c[:2] == ["release", "upload"] and not Path(c[3]).name.startswith(SIDECARS)
+    ]
     assets = sorted(Path(c[3]).name for c in uploads)
     # The manifest is load-bearing: wehoop exports load_wnba_standings_manifest().
     assert assets == [
@@ -130,6 +141,10 @@ def test_publish_tolerates_create_race(tmp_path):
         runner=runner,
         exists_check=lambda tag, repo: False,
     )
-    uploads = [c for c in calls if c[:2] == ["release", "upload"]]
+    uploads = [
+        c
+        for c in calls
+        if c[:2] == ["release", "upload"] and not Path(c[3]).name.startswith(SIDECARS)
+    ]
     assert len(uploads) == 3
     assert res["uploaded"] == 3

--- a/tests/wnba_data_build/test_release_sidecars.py
+++ b/tests/wnba_data_build/test_release_sidecars.py
@@ -1,0 +1,54 @@
+"""The release sidecars R's sportsdataverse_save() attaches to every tag.
+
+Dropping them is what left published tags carrying a timestamp.json frozen at
+the last R run while the data kept moving -- a consumer reading it to decide
+whether to re-download got a confident wrong answer.
+"""
+
+import json
+from pathlib import Path
+
+from wnba_data_build import publish
+from wnba_data_build.config import PKG_FUNCTION, REGISTRY
+
+SIDECAR_NAMES = [
+    "timestamp.txt",
+    "timestamp.json",
+    "package_function.txt",
+    "package_function.json",
+]
+
+
+def test_stamp_uploads_the_four_sidecars_with_clobber():
+    calls: list[list[str]] = []
+
+    publish._stamp("espn_wnba_draft", calls.append, "sportsdataverse/sportsdataverse-data")
+
+    assert [Path(c[3]).name for c in calls] == SIDECAR_NAMES
+    assert all(c[:3] == ["release", "upload", "espn_wnba_draft"] for c in calls)
+    assert all(c[-1] == "--clobber" for c in calls)
+    # written to a temp dir that is cleaned up behind the upload
+    assert not any(Path(c[3]).exists() for c in calls)
+
+
+def test_stamp_names_the_loader_for_the_tag():
+    """The package_function pair carries the tag's loader, both formats."""
+    seen: dict[str, str] = {}
+
+    def _runner(argv: list[str]) -> None:
+        # read inside the runner: the temp dir is cleaned up behind the upload
+        path = Path(argv[3])
+        seen[path.name] = path.read_text()
+
+    publish._stamp("espn_wnba_draft", _runner, "sportsdataverse/sportsdataverse-data")
+
+    expected = PKG_FUNCTION["espn_wnba_draft"]
+    assert seen["package_function.txt"].strip() == expected
+    assert json.loads(seen["package_function.json"])["package_function"] == expected
+    assert json.loads(seen["timestamp.json"])["last_updated"].strip()
+
+
+def test_every_registry_tag_has_a_package_function():
+    """A new dataset must not publish a tag with no loader named on it."""
+    missing = sorted({s.tag for s in REGISTRY.values()} - set(PKG_FUNCTION))
+    assert missing == [], f"tags with no PKG_FUNCTION entry: {missing}"


### PR DESCRIPTION
## Why

R's `sportsdataversedata::sportsdataverse_save()` attaches four sidecars to every tag it publishes — `timestamp.txt`/`.json` and `package_function.txt`/`.json`. This repo's Python publisher hand-rolled `gh release upload --clobber` and dropped that half.

Audited across all 241 tags on `sportsdataverse/sportsdataverse-data` today:

| | tags |
|---|---:|
| no sidecar at all | 133 |
| sidecar present but **stale** — written by the last R run while the data kept moving | 95 |
| sidecar in sync | 13 |

Stale is the worse failure. A consumer reading `timestamp.json` to decide whether to re-download gets a confident wrong answer; absent at least fails loudly. Worst on the board: `ncaa_baseball_pbp` 1271 days, `espn_cfb_pbp` / `espn_cfb_rosters` 1214, then the ESPN NBA/WNBA/MBB/WBB families at 37-50 — all dating to their R→Python producer flips.

Root cause was structural, not per-repo: sdv-py's sidecar writer was private, reachable only through `sportsdataverse_upload()`, and each of the 15 Python producers owns its own upload transport (one file per `gh` invocation, a longer timeout for 100MB+ assets, an injected `runner` that keeps tests offline). None could emit the sidecars without re-deriving the format, and none did.

## What

`publish` now calls `sportsdataverse.release.upload_release_sidecars` (added in sportsdataverse-py#429) through the same injected `runner` as the data assets:

- **last**, so the stamp describes a *finished* upload rather than the start of one;
- **only when something actually uploaded**, so a no-op run cannot claim the data moved.

`PKG_FUNCTION` maps tag → loader name. The values are not invented — where the R producer already published a `package_function` to the tag, that exact string is reused (read back off the release assets), so re-stamping from Python does not change what a consumer sees. Python-only tags that never had one name the sdv-py loader.

## Test

- the four sidecars upload in order, with `--clobber`, under the right tag, and their temp dir is cleaned up behind them;
- the `package_function` pair carries the tag's loader in both formats, and `timestamp.json` carries a `last_updated`;
- every `REGISTRY` tag has a `PKG_FUNCTION` entry, so a new dataset cannot ship an unnamed tag;
- existing upload assertions now filter the sidecars out, which preserves each one's original meaning.

Full suite green locally.

## Summary by Sourcery

Ensure Python release updates keep timestamp and package-function metadata synchronized with the published data.

New Features:
- Stamp every successfully updated release with timestamp and package-function sidecar assets.
- Define loader names for all registered WNBA release tags, preserving existing R producer values where applicable.

Bug Fixes:
- Prevent release metadata from being absent or stale after Python data uploads.
- Avoid stamping releases when a publish run uploads no data assets.

Enhancements:
- Reuse the shared sportsdataverse sidecar uploader and the publisher's injected runner for consistent, testable release updates.

Tests:
- Add coverage for sidecar upload order, clobbering, cleanup, timestamp and loader metadata, and complete registry coverage.
- Update upload assertions to exclude release metadata sidecars from data-asset checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release uploads now include timestamp and package-function metadata, identifying when data was published and how it can be loaded.
  * Added loader information for each supported release tag.

* **Bug Fixes**
  * Restored release metadata stamping for both dataset and file publishing workflows.

* **Tests**
  * Added coverage for metadata uploads, loader naming, timestamps, file replacement, cleanup, and release-tag coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->